### PR TITLE
JSON representation does not set xs:type=string (that's the default).

### DIFF
--- a/src/main/_framework/domain-impl.xqy
+++ b/src/main/_framework/domain-impl.xqy
@@ -2921,7 +2921,8 @@ declare function domain-impl:get-param-value(
                 $value/node()
             else
               $value
-
+        else if ($value instance of xs:untypedAtomic) then
+          fn:string($value)
         else
           $value
     else
@@ -2952,6 +2953,8 @@ declare function domain-impl:get-param-value(
                     $value/fn:data()
                   else
                     $value/node()
+                else if ($value instance of xs:untypedAtomic) then
+                  fn:string($value)
                 else
                   $value
           case "param"


### PR DESCRIPTION
Make sure untypedAtomic are converted to string