### PR TITLE
Fix #144

### DIFF
--- a/src/main/_framework/services/applications-controller.xqy
+++ b/src/main/_framework/services/applications-controller.xqy
@@ -23,7 +23,8 @@ return
           fn:string($application/@name)
         },
         element {fn:QName("http://xquerrail.com/application", "domain")} {
-          $domain-link
+          element {fn:QName("http://xquerrail.com/application", "timestamp")} { fn:string(config:get-domain($application/@name)/@timestamp) },
+          element {fn:QName("http://xquerrail.com/application", "link")} { $domain-link }
         }
       }
     }
@@ -38,7 +39,14 @@ return
         let $domain-link := fn:concat("/applications/", fn:string($application/@name) , "/domain/get.", $format)
         let $json-application := json:object()
         let $_ := map:put($json-application, "name", fn:string($application/@name))
-        let $_ := map:put($json-application, "domain", $domain-link)
+        let $_ := map:put(
+          $json-application,
+          "domain",
+          map:new((
+            map:entry("timestamp", fn:string(config:get-domain($application/@name)/@timestamp)),
+            map:entry("link", $domain-link)
+          ))
+        )
         return $json-application
       )
     )

--- a/src/test/mocha/test/application-controllers-test.js
+++ b/src/test/mocha/test/application-controllers-test.js
@@ -57,7 +57,8 @@ describe('Application controllers (applications, domains)', function() {
         var application = entity.applications[0];
         expect(application).to.have.property('name');
         expect(application).to.have.property('domain');
-        expect(application.domain).to.equal('/applications/' + application.name + '/domain/get.json');
+        expect(application.domain).to.have.property('link');
+        expect(application.domain.link).to.equal('/applications/' + application.name + '/domain/get.json');
         xquerrailCommon.httpMethod('GET', 'applications/' + application.name + '/domain', 'get', undefined, undefined, function(error, response, entity) {
           expect(response.statusCode).to.equal(200);
           expect(entity).to.have.property('domain');
@@ -75,7 +76,8 @@ describe('Application controllers (applications, domains)', function() {
         var application = entity.applications.application[0];
         expect(application).to.have.property('name');
         expect(application).to.have.property('domain');
-        expect(application.domain).to.equal('/applications/' + application.name + '/domain/get.xml');
+        expect(application.domain).to.have.property('link');
+        expect(application.domain.link).to.equal('/applications/' + application.name + '/domain/get.xml');
         xquerrailCommon.httpMethod('GET', 'applications/' + application.name + '/domain', 'get', undefined, undefined, function(error, response, entity) {
           expect(response.statusCode).to.equal(200);
           expect(entity).to.have.property('domain');


### PR DESCRIPTION
/applications/${application-name}/domain/get.xml has been changed to return timestamp and link

```xml
<applications xmlns="http://xquerrail.com/application">
  <application>
    <name>app-test</name>
    <domain>
      <timestamp>2015-10-30T09:39:32.896741Z</timestamp>
      <link>/applications/app-test/domain/get.xml</link>
    </domain>
  </application>
</applications>
```