### PR TITLE
Fix #157

### DIFF
--- a/src/main/_framework/application.xqy
+++ b/src/main/_framework/application.xqy
@@ -49,7 +49,6 @@ declare %private function app:load-application(
   $application-name as xs:string
 ) as element(domain:domain)? {
   let $application-path := fn:concat(config:application-directory($application-name), "/domains/application-domain.xml")
-  let $_ := xdmp:log(text{"config:load-domain", $application-name, "$application-path", $application-path}, "debug")
   let $domain-config := config:get-resource($application-path)
   let $domain := app:load-domain($application-name, $domain-config)
   let $config := config:get-config()
@@ -201,8 +200,8 @@ declare %private function app:get-base-safe($path as xs:string) as element(confi
 declare function app:reset() as item()* {
   try {
     xdmp:function(xs:QName("extension:reset"), "generators/bootstrap-generator.xqy")()
-  } catch ($ex) {
-    xdmp:log($ex)
+  } catch ($exception) {
+    xdmp:log($exception, "warning")
   },
   config:clear-cache()
 };

--- a/src/main/_framework/base/views/base.search.json.xqy
+++ b/src/main/_framework/base/views/base.search.json.xqy
@@ -90,11 +90,11 @@ return
           (:Metrics:)
           js:entry("metrics",js:object(
             $node/search:metrics ! (
-              js:keyvalue("query_time",./search:query-resolution-time),
-              js:keyvalue("facet_time",./search:facet-resolution-time),
-              js:keyvalue("snippet_time",./search:snippet-resolution-time),
-              js:keyvalue("metadata_time",./search:metadata-resolution-time),
-              js:keyvalue("total_time",./search:total_time)
+              if (fn:string(./search:query-resolution-time) ne "") then js:keyvalue("query_time",./search:query-resolution-time) else (),
+              if (fn:string(./search:facet-resolution-time) ne "") then js:keyvalue("facet_time",./search:facet-resolution-time) else (),
+              if (fn:string(./search:snippet-resolution-time) ne "") then js:keyvalue("snippet_time",./search:snippet-resolution-time) else (),
+              if (fn:string(./search:metadata-resolution-time) ne "") then js:keyvalue("metadata_time",./search:metadata-resolution-time) else (),
+              if (fn:string(./search:total-time) ne "") then js:keyvalue("total_time",./search:total-time) else ()
             )
           ))
         )))


### PR DESCRIPTION
XQuery example to invoke the dispatcher from QConsole

```
xquery version "1.0-ml";
import module namespace request = "http://xquerrail.com/request" at "/main/_framework/request.xqy";
import module namespace domain = "http://xquerrail.com/domain" at "/main/_framework/domain.xqy";
declare option xdmp:mapping "false";

let $request := json:object()
let $_ := (
  map:put($request, "type", "request:request"),
  map:put($request, "request:method","PUT"),
  map:put($request, "request:route","default_controller_action_format"),
  map:put($request, "request:application","app-test"),
  map:put($request, "request:controller","documents"),
  map:put($request, "request:action","insert"),
  map:put($request, "request:format","xml"),
  map:put($request, "request:param::uri","/text/4.xml")
)

return
  xdmp:invoke(
     "/main/_framework/dispatchers/dispatcher.web.xqy",
     map:new((
       map:entry("{http://xquerrail.com/domain}REQUEST-EXTERNAL", $request),
       map:entry("{http://xquerrail.com/domain}REQUEST-BODY-EXTERNAL", <trade><name>trade-1</name></trade>)
     ))
  )
```